### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Returns an object with an `alpnProtocol` property. The `socket` property may be 
 ```js
 const result = await resolveALPN({
 	host: 'nghttp2.org',
-  port: 443,
+	port: 443,
 	ALPNProtocols: ['h2', 'http/1.1']
 	servername: 'nghttp2.org'
 });
@@ -33,9 +33,9 @@ If you set this to true, it will return the socket in a `socket` property.
 ```js
 const result = await resolveALPN({
 	host: 'nghttp2.org',
-  port: 443,
+	port: 443,
 	ALPNProtocols: ['h2', 'http/1.1'],
-  servername: 'nghttp2.org',
+	servername: 'nghttp2.org',
 	resolveSocket: true
 });
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,9 @@ Returns an object with an `alpnProtocol` property. The `socket` property may be 
 ```js
 const result = await resolveALPN({
 	host: 'nghttp2.org',
-	ALPNProtocols: ['h2', 'http/1.1']
+        servername: 'nghttp2.org',
+	ALPNProtocols: ['h2', 'http/1.1'],
+        port: 443
 });
 
 console.log(result); // {alpnProtocol: 'h2'}
@@ -29,7 +31,9 @@ If you set this to true, it will return the socket in a `socket` property.
 ```js
 const result = await resolveALPN({
 	host: 'nghttp2.org',
+        servername: 'nghttp2.org',
 	ALPNProtocols: ['h2', 'http/1.1'],
+        port: 443,	
 	resolveSocket: true
 });
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Returns an object with an `alpnProtocol` property. The `socket` property may be 
 const result = await resolveALPN({
 	host: 'nghttp2.org',
 	port: 443,
-	ALPNProtocols: ['h2', 'http/1.1']
+	ALPNProtocols: ['h2', 'http/1.1'],
 	servername: 'nghttp2.org'
 });
 


### PR DESCRIPTION
Hey there thanks for this nice little lib.
Looks like we need to pass more tls.ConnectionOptions to resolve ALPN on most remote server
Updating the readme with working examples (at least for me running on Node v12.x)

servername is not strictly needed for `nghttp2.org` but might be good to include anyway for people copy pasting this snippet for server using SNI